### PR TITLE
Upgrade SixLabors.ImageSharp from 3.1.6 to 3.1.12

### DIFF
--- a/src/Clickwheel/Clickwheel.csproj
+++ b/src/Clickwheel/Clickwheel.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\ArtworkDB-empty" />

--- a/src/Clickwheel/packages.lock.json
+++ b/src/Clickwheel/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "SixLabors.ImageSharp": {
         "type": "Direct",
-        "requested": "[3.1.6, )",
-        "resolved": "3.1.6",
-        "contentHash": "dHQ5jugF9v+5/LCVHCWVzaaIL6WOehqJy6eju/0VFYFPEj2WtqkGPoEV9EVQP83dHsdoqYaTuWpZdwAd37UwfA=="
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",

--- a/tests/Clickwheel.Tests/packages.lock.json
+++ b/tests/Clickwheel.Tests/packages.lock.json
@@ -307,8 +307,8 @@
       },
       "SixLabors.ImageSharp": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "dHQ5jugF9v+5/LCVHCWVzaaIL6WOehqJy6eju/0VFYFPEj2WtqkGPoEV9EVQP83dHsdoqYaTuWpZdwAd37UwfA=="
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -1144,7 +1144,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Data.Sqlite": "[6.0.4, )",
-          "SixLabors.ImageSharp": "[3.1.6, )"
+          "SixLabors.ImageSharp": "[3.1.12, )"
         }
       }
     }


### PR DESCRIPTION
ImageSharp has a couple of vulnerabilities in version 3.1.6:
- <https://github.com/advisories/GHSA-2cmq-823j-5qj8>
- <https://github.com/advisories/GHSA-rxmq-m78w-7wmc>